### PR TITLE
Fix #55: added support for BASIC auth.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'nokogiri'
 gem 'picky' # has a more performant array intersection method
 gem 'timecop'
 gem 'rspec-rails'
+gem 'bcrypt'
 
 gem 'rails_12factor', group: :production
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
+    bcrypt (3.1.10)
     builder (3.2.2)
     chunky_png (1.3.4)
     coderay (1.1.0)
@@ -224,6 +225,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt
   coffee-rails
   compass-rails
   database_cleaner
@@ -244,3 +246,6 @@ DEPENDENCIES
   timecop
   turbolinks
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ This app uses the [figaro](https://github.com/laserlemon/figaro) gem, so it is r
 COMPANY_NAME: "Initech"
 COMPANY_NAME_POSSESSIVE: "Initech's"
 PRODUCTION_DOMAIN: "guarded-stream-9823.herokuapp.com"
+SUP_USER_NAME: "username"
+SUP_PASSWORD_HASH: "..."
 SMTP_USER_NAME: "ilyakava@initech.com"
 SMTP_PASSWORD: "lumberghrulz"
 SMTP_DOMAIN: "guarded-stream-9823.herokuapp.com
@@ -78,6 +80,17 @@ SMTP_DOMAIN: "guarded-stream-9823.herokuapp.com
 - `PRODUCTION_DOMAIN` should be the web address (without `http` or `www`) for where you are hosting your app.
 - `SMTP_USER_NAME` and `SMTP_PASSWORD` are your email address user name and password. These are used by the app to automatically send emails from the given address.
 - `SMTP_DOMAIN` can be the same as `PRODUCTION_DOMAIN`
+
+You should put the app under SSL and restrict its access with a username/password.
+
+- `SUP_USERNAME`: the username for a shared login
+- `SUP_PASSWORD_HASH`: generate as follows:
+
+```ruby
+require 'bcrypt'
+BCrypt::Password.create('password')
+ => "$2a$10$yKF3BYd1sbZNvandxGJg4.EsQcYd41UP1FJrs6PwrcA6gJ3rQIA8u"
+```
 
 An optional but **recommended** environment variable is:
 
@@ -136,5 +149,5 @@ Run `rake fspec` to exclude the slow specs that check the convergence of the pai
 ## License
 
 (c) Artsy, 2015 + Ilya Kavalerov
- 
+
 MIT

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,13 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  # BASIC auth
+  before_filter :authenticate
+
+  def authenticate
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV['SUP_USER_NAME'] && BCrypt::Password.new(ENV['SUP_PASSWORD_HASH']) == password
+    end if ENV['SUP_USER_NAME']
+  end
 end

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe MembersController do
+  describe '#graph' do
+    context 'without SUP_USER_NAME' do
+      it 'does not prompt for authentication' do
+        get :index
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'with SUP_USER_NAME and SUP_PASSWORD_HASH' do
+      before do
+        ENV['SUP_USER_NAME'] = 'username'
+        ENV['SUP_PASSWORD_HASH'] = BCrypt::Password.create('password')
+      end
+
+      after do
+        ENV.delete 'SUP_USER_NAME'
+        ENV.delete 'SUP_PASSWORD'
+      end
+
+      it 'prompts for HTTP Basic authentication' do
+        get :index
+        expect(response.status).to eq 401
+      end
+
+      it 'accepts correct username/password' do
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('username', 'password')
+        get :index
+        expect(response.status).to eq 200
+      end
+
+      it 'denies access with incorrect username/password' do
+        request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('username', 'invalid')
+        get :index
+        expect(response.status).to eq 401
+      end
+    end
+  end
+end


### PR DESCRIPTION
Set `SUP_USERNAME` to a username.
Set `SUP_PASSWORD_HASH` to

```ruby
require 'bcrypt'
BCrypt::Password.create('password')
```