### PR TITLE
fixed README: where to put 'application.yml'

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This is a rails app that can easily be [deployed with heroku](https://devcenter.
 
 ### Environment variables
 
-This app uses the [figaro](https://github.com/laserlemon/figaro) gem, so it is recommended that you place all your environment variables in a `application.yml` file in the root directory of the app. The **required** environment variables are:
+This app uses the [figaro](https://github.com/laserlemon/figaro) gem, so it is recommended that you place all your environment variables in a `application.yml` file in the `config` directory of the app. The **required** environment variables are:
 
 ```
 COMPANY_NAME: "Initech"


### PR DESCRIPTION
I noticed that the README says to put 'application.yml' into the root directory but I believe it's usually in the config directory. That is also where '.gitignore' is looking. Is this correct?